### PR TITLE
MB-33556: Call the OnFlushCompleted handler unconditionally

### DIFF
--- a/db/compact_files_test.cc
+++ b/db/compact_files_test.cc
@@ -38,6 +38,9 @@ class FlushedFileCollector : public EventListener {
   ~FlushedFileCollector() {}
 
   virtual void OnFlushCompleted(DB* /*db*/, const FlushJobInfo& info) override {
+    if (!info.status.ok()) {
+      return;
+    }
     std::lock_guard<std::mutex> lock(mutex_);
     flushed_files_.push_back(info.file_path);
   }

--- a/db/db_compaction_test.cc
+++ b/db/db_compaction_test.cc
@@ -56,6 +56,9 @@ class FlushedFileCollector : public EventListener {
   ~FlushedFileCollector() {}
 
   virtual void OnFlushCompleted(DB* /*db*/, const FlushJobInfo& info) override {
+    if (!info.status.ok()) {
+      return;
+    }
     std::lock_guard<std::mutex> lock(mutex_);
     flushed_files_.push_back(info.file_path);
   }
@@ -102,7 +105,10 @@ public:
   }
 
   virtual void OnFlushCompleted(DB* /* db */,
-      const FlushJobInfo& /* info */) override {
+      const FlushJobInfo& info) override {
+    if (!info.status.ok()) {
+      return;
+    }
     int k = static_cast<int>(CompactionReason::kFlush);
     compaction_completed_[k]++;
   }

--- a/db/db_impl.h
+++ b/db/db_impl.h
@@ -743,7 +743,8 @@ class DBImpl : public DB {
 
   void NotifyOnFlushCompleted(ColumnFamilyData* cfd, FileMetaData* file_meta,
                               const MutableCFOptions& mutable_cf_options,
-                              int job_id, TableProperties prop);
+                              const Status& st, int job_id,
+                              TableProperties prop);
 
   void NotifyOnCompactionBegin(ColumnFamilyData* cfd,
                                Compaction *c, const Status &st,

--- a/db/db_impl_compaction_flush.cc
+++ b/db/db_impl_compaction_flush.cc
@@ -187,11 +187,12 @@ Status DBImpl::FlushMemTableToOutputFile(
     Status new_bg_error = s;
     error_handler_.SetBGError(new_bg_error, BackgroundErrorReason::kFlush);
   }
-  if (s.ok()) {
 #ifndef ROCKSDB_LITE
-    // may temporarily unlock and lock the mutex.
-    NotifyOnFlushCompleted(cfd, &file_meta, mutable_cf_options,
-                           job_context->job_id, flush_job.GetTableProperties());
+  // may temporarily unlock and lock the mutex.
+  NotifyOnFlushCompleted(cfd, &file_meta, mutable_cf_options, s,
+                         job_context->job_id, flush_job.GetTableProperties());
+
+  if (s.ok()) {
     auto sfm = static_cast<SstFileManagerImpl*>(
         immutable_db_options_.sst_file_manager.get());
     if (sfm) {
@@ -207,8 +208,8 @@ Status DBImpl::FlushMemTableToOutputFile(
         error_handler_.SetBGError(new_bg_error, BackgroundErrorReason::kFlush);
       }
     }
-#endif  // ROCKSDB_LITE
   }
+#endif  // ROCKSDB_LITE
   return s;
 }
 
@@ -468,7 +469,8 @@ Status DBImpl::AtomicFlushMemTablesToOutputFiles(
         continue;
       }
       NotifyOnFlushCompleted(cfds[i], &file_meta[i], all_mutable_cf_options[i],
-                             job_context->job_id, jobs[i].GetTableProperties());
+                             s, job_context->job_id,
+                             jobs[i].GetTableProperties());
       if (sfm) {
         std::string file_path = MakeTableFileName(
             cfds[i]->ioptions()->cf_paths[0].path, file_meta[i].fd.GetNumber());
@@ -533,6 +535,7 @@ void DBImpl::NotifyOnFlushBegin(ColumnFamilyData* cfd, FileMetaData* file_meta,
     info.cf_name = cfd->GetName();
     // TODO(yhchiang): make db_paths dynamic in case flush does not
     //                 go to L0 in the future.
+    info.status = Status::OK();
     info.file_path = MakeTableFileName(cfd->ioptions()->cf_paths[0].path,
                                        file_meta->fd.GetNumber());
     info.thread_id = env_->GetThreadID();
@@ -562,7 +565,8 @@ void DBImpl::NotifyOnFlushBegin(ColumnFamilyData* cfd, FileMetaData* file_meta,
 void DBImpl::NotifyOnFlushCompleted(ColumnFamilyData* cfd,
                                     FileMetaData* file_meta,
                                     const MutableCFOptions& mutable_cf_options,
-                                    int job_id, TableProperties prop) {
+                                    const Status& st, int job_id,
+                                    TableProperties prop) {
 #ifndef ROCKSDB_LITE
   if (immutable_db_options_.listeners.size() == 0U) {
     return;
@@ -584,6 +588,7 @@ void DBImpl::NotifyOnFlushCompleted(ColumnFamilyData* cfd,
     info.cf_name = cfd->GetName();
     // TODO(yhchiang): make db_paths dynamic in case flush does not
     //                 go to L0 in the future.
+    info.status = st;
     info.file_path = MakeTableFileName(cfd->ioptions()->cf_paths[0].path,
                                        file_meta->fd.GetNumber());
     info.thread_id = env_->GetThreadID();

--- a/db/db_sst_test.cc
+++ b/db/db_sst_test.cc
@@ -28,6 +28,9 @@ class FlushedFileCollector : public EventListener {
   ~FlushedFileCollector() {}
 
   virtual void OnFlushCompleted(DB* /*db*/, const FlushJobInfo& info) override {
+    if (!info.status.ok()) {
+      return;
+    }
     std::lock_guard<std::mutex> lock(mutex_);
     flushed_files_.push_back(info.file_path);
   }

--- a/db/listener_test.cc
+++ b/db/listener_test.cc
@@ -199,6 +199,9 @@ class TestFlushListener : public EventListener {
 
   void OnFlushCompleted(
       DB* db, const FlushJobInfo& info) override {
+    if (!info.status.ok()) {
+      return;
+    }
     flushed_dbs_.push_back(db);
     flushed_column_family_names_.push_back(info.cf_name);
     if (info.triggered_writes_slowdown) {
@@ -745,6 +748,9 @@ public:
 
   void OnFlushCompleted(DB* /*db*/,
     const FlushJobInfo& flush_job_info) override {
+    if (!flush_job_info.status.ok()) {
+      return;
+    }
     ASSERT_LE(flush_job_info.smallest_seqno, latest_seq_number_);
   }
 };

--- a/examples/compact_files_example.cc
+++ b/examples/compact_files_example.cc
@@ -72,6 +72,9 @@ class FullCompactor : public Compactor {
   // compaction-task to true.
   void OnFlushCompleted(
       DB* db, const FlushJobInfo& info) override {
+    if (!info.status.ok()) {
+      return;
+    }
     CompactionTask* task = PickCompaction(db, info.cf_name);
     if (task != nullptr) {
       if (info.triggered_writes_stop) {

--- a/include/rocksdb/listener.h
+++ b/include/rocksdb/listener.h
@@ -186,6 +186,8 @@ struct FlushJobInfo {
   TableProperties table_properties;
 
   FlushReason flush_reason;
+  // the status indicating whether the flush was successful or not.
+  Status status;
 };
 
 struct CompactionJobInfo {

--- a/tools/db_stress.cc
+++ b/tools/db_stress.cc
@@ -1247,6 +1247,9 @@ class DbStressListener : public EventListener {
   }
 #ifndef ROCKSDB_LITE
   virtual void OnFlushCompleted(DB* /*db*/, const FlushJobInfo& info) override {
+    if (!info.status.ok()) {
+      return;
+    }
     assert(IsValidColumnFamilyName(info.cf_name));
     VerifyFilePath(info.file_path);
     // pretending doing some work here

--- a/utilities/blob_db/blob_db_listener.h
+++ b/utilities/blob_db/blob_db_listener.h
@@ -26,7 +26,10 @@ class BlobDBListener : public EventListener {
     blob_db_impl_->SyncBlobFiles();
   }
 
-  void OnFlushCompleted(DB* /*db*/, const FlushJobInfo& /*info*/) override {
+  void OnFlushCompleted(DB* /*db*/, const FlushJobInfo& info) override {
+    if (!info.status.ok()) {
+      return;
+    }
     assert(blob_db_impl_ != nullptr);
     blob_db_impl_->UpdateLiveSSTSize();
   }


### PR DESCRIPTION
In the case of a shutdown or other reasons in which a flush may
not complete, OnFlushCompleted is not called because the Status is
not OK. Instead, pass the status through to the event listener via the
FlushJobInfo and allow the listener to deal with any failure as they
see fit.